### PR TITLE
Catch alll subdirectories from .app/usr/include

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -62,22 +62,24 @@ done
 
 topic "Writing profile script"
 lib_paths=`cd $BUILD_DIR; find .apt/usr/lib -depth -type d | sed 's/^/\$HOME\//' | tr "\\n" :`
+include_paths=`cd $BUILD_DIR; find .apt/usr/include -depth -type d | sed 's/^/\$HOME\//' | tr "\\n" :`
 mkdir -p $BUILD_DIR/.profile.d
 cat <<EOF >$BUILD_DIR/.profile.d/000_apt.sh
 export PATH="\$HOME/.apt/usr/bin:\$PATH"
 export LD_LIBRARY_PATH="$lib_paths\$LD_LIBRARY_PATH"
 export LIBRARY_PATH="$lib_paths\$LIBRARY_PATH"
-export INCLUDE_PATH="\$HOME/.apt/usr/include:\$INCLUDE_PATH"
+export INCLUDE_PATH="$include_paths\$INCLUDE_PATH"
 export CPATH="\$INCLUDE_PATH"
 export CPPPATH="\$INCLUDE_PATH"
 export PKG_CONFIG_PATH="\$HOME/.apt/usr/lib/x86_64-linux-gnu/pkgconfig:\$HOME/.apt/usr/lib/i386-linux-gnu/pkgconfig:\$HOME/.apt/usr/lib/pkgconfig:\$PKG_CONFIG_PATH"
 EOF
 
 lib_paths=`find $BUILD_DIR/.apt/usr/lib -depth -type d | tr "\\n" :`
+include_paths=`find $BUILD_DIR/.apt/usr/include -depth -type d | tr "\\n" :`
 export PATH="$BUILD_DIR/.apt/usr/bin:$PATH"
 export LD_LIBRARY_PATH="$lib_paths$LD_LIBRARY_PATH"
 export LIBRARY_PATH="$lib_paths$LIBRARY_PATH"
-export INCLUDE_PATH="$BUILD_DIR/.apt/usr/include:$INCLUDE_PATH"
+export INCLUDE_PATH="$include_paths$INCLUDE_PATH"
 export CPATH="$INCLUDE_PATH"
 export CPPPATH="$INCLUDE_PATH"
 export PKG_CONFIG_PATH="$BUILD_DIR/.apt/usr/lib/x86_64-linux-gnu/pkgconfig:$BUILD_DIR/.apt/usr/lib/i386-linux-gnu/pkgconfig:$BUILD_DIR/.apt/usr/lib/pkgconfig:$PKG_CONFIG_PATH"


### PR DESCRIPTION
Same as 51bb5feb62 but for includes.
This fixed python-ldap requiring libsasl-dev but should fix anything relying on header files to build stuff.
